### PR TITLE
✨ 비로그인 시 장바구니 추가 불가

### DIFF
--- a/src/page/product/ProductDetail.tsx
+++ b/src/page/product/ProductDetail.tsx
@@ -110,14 +110,20 @@ export default function ProductDetail() {
                 ) : (
                   <Button disabled>Add to Cart</Button>
                 )
-              ) : isInCart ? (
-                <Link to={`/cart/${user?.id}`} className="w-full">
-                  <Button>See the Cart</Button>
-                </Link>
-              ) : product.productQuantity == 0 ? (
-                <div className="text-3xl text-red-400">Sold out</div>
+              ) : user ? (
+                isInCart ? (
+                  <Link to={`/cart/${user?.id}`} className="w-full">
+                    <Button>See the Cart</Button>
+                  </Link>
+                ) : product.productQuantity == 0 ? (
+                  <div className="text-3xl text-red-400">Sold out</div>
+                ) : (
+                  <Button onClick={addCartMutation.mutate}>Add to Cart</Button>
+                )
               ) : (
-                <Button onClick={addCartMutation.mutate}>Add to Cart</Button>
+                <Link to="/signup" className="w-full">
+                  <Button>Add to Cart</Button>
+                </Link>
               )}
             </section>
           </section>

--- a/src/query/product/fetchInfinityProduct.tsx
+++ b/src/query/product/fetchInfinityProduct.tsx
@@ -26,7 +26,7 @@ export default async function fetchInfinityProduct({
 
   // 실행
   try {
-    let q = query(collection(db, _key), limit(6));
+    let q = query(collection(db, _key), limit(4));
 
     // 판매자 본인 확인
     if (user == params) {


### PR DESCRIPTION
# ⚡ PR 요약
✨ 비로그인 시 장바구니 추가 불가

# 🔍 주요 변경 사항
1. 비회원 장바구니 추가 불가 기능
2. 판매자 페이지 상품 불러오기 갯수 변경

# 💡 관련 이슈
Resolve #53 
